### PR TITLE
RANCHER-3013: Pin folio-application-generator to 1.4.0 on R1-2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.name>app-service-interaction</project.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <folio-application-generator.version>1.4.0-SNAPSHOT</folio-application-generator.version>
+        <folio-application-generator.version>1.4.0</folio-application-generator.version>
         <templatePath>${basedir}/application.template.json</templatePath>
     </properties>
 


### PR DESCRIPTION
The Trillium release branch \`R1-2026\` carried \`folio-application-generator\` at \`1.4.0-SNAPSHOT\`. A release branch must not depend on an unreleased snapshot, so this pins it to the released \`1.4.0\` (tag \`v1.4.0\`).

Part of RANCHER-3013 — one PR per affected app (8 ERM-domain apps).